### PR TITLE
Add build and push for development images on push to `main`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
             type=raw,value=${{ env.docker_tag }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
-      - name: Build and push release images
+      - name: Build and push images
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,23 +43,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push development images
-        uses: docker/build-push-action@v4
+      - name: Build Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          context: .
-          push: ${{ github.event_name == 'push' }}
+          images: |
+            simonsobs/scheduler-server
+            ghcr.io/simonsobs/scheduler-server
           tags: |
-            simonsobs/scheduler-server:${{ env.docker_tag }}
-            ghcr.io/simonsobs/scheduler-server:${{ env.docker_tag }}
+            type=raw,value=${{ env.docker_tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push release images
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name == 'release' }}
-          tags: |
-            simonsobs/scheduler-server:latest
-            simonsobs/scheduler-server:${{ env.docker_tag }}
-            ghcr.io/simonsobs/scheduler-server:latest
-            ghcr.io/simonsobs/scheduler-server:${{ env.docker_tag }}
-
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: Publish Images to Container Registries
 on:
   release:
     types: [ released ]
+  push:
+    branches: [ main ]
   pull_request:
 
 jobs:
@@ -12,6 +14,11 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -36,11 +43,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push development images
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            simonsobs/scheduler-server:${{ env.docker_tag }}
+            ghcr.io/simonsobs/scheduler-server:${{ env.docker_tag }}
+
+      - name: Build and push release images
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name == 'release' }}
           tags: |
             simonsobs/scheduler-server:latest
             simonsobs/scheduler-server:${{ env.docker_tag }}


### PR DESCRIPTION
This should add building and pushing docker images with a tag based on the current git hash when pushing to `main`. "latest" images are still only pushed on release.

This should allow more rapid testing of the work between releases.