### PR TITLE
Add related packages and badges to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # scheduler-server
 
+[![Image Builds](https://img.shields.io/github/actions/workflow/status/simonsobs/scheduler-server/build.yaml?branch=main)](https://github.com/simonsobs/scheduler-server/actions/workflows/build.yaml?query=workflow%3A%22Publish+Images+to+Container+Registries%22)
+[![Docker Hub](https://img.shields.io/badge/dockerhub-latest-blue)](https://hub.docker.com/r/simonsobs/scheduler-server)
+
 ## Related Packages
 
 * [**scheduler**](https://github.com/simonsobs/scheduler) - The core scheduling

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,14 @@
 # scheduler-server
 
+## Related Packages
+
+* [**scheduler**](https://github.com/simonsobs/scheduler) - The core scheduling
+  library, a.k.a. `schedlib`.
+* [**scheduler-server**](https://github.com/simonsobs/scheduler-server) - This
+  package. The Flask API for fetching schedules.
+* [**scheduler-web**](https://github.com/simonsobs/scheduler-web) - The web
+  front end for the scheduler.
+
 ## Installation
 First clone this repository, and then install it with
 ```bash


### PR DESCRIPTION
Just a few quality of life additions to the README. I always find myself on one of the scheduler repos and looking for another one for reference. Inspired by nextline's readme I've added a list of all the scheduler related repos.

I've also added badges for the image build which indicate whether builds are successful and a link to the Dockerhub image.