### PR TITLE
Specify schedlib version in requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ gunicorn
 numpy
 pyyaml
 pandas
-schedlib @ git+https://github.com/simonsobs/scheduler.git@main
+schedlib @ git+https://github.com/simonsobs/scheduler.git@v0.1.0


### PR DESCRIPTION
Closing the loop on the versioning PRs -- this pins the version of schedlib in the requirements file. This means updating this pinned version when we need to bump schedlib versions, but it give us something to track here for meaningfully tagging the server docker images.

Current motivation is to get the updated schedule format reading into the server so we can run one of those schedules at site.