### PR TITLE
Auto scheduler changes

### DIFF
--- a/src/scheduler_server/app.py
+++ b/src/scheduler_server/app.py
@@ -139,5 +139,9 @@ def get_preset_config(preset_name, default={}):
             'url': os.environ['NOCODB_SATP3_URL'],
             **http_headers,
         }
+        'rest.lat': {
+            'url': os.environ['NOCODB_LAT_URL'],
+            **http_headers,
+        }
     }
     return presets.get(preset_name, default)

--- a/src/scheduler_server/app.py
+++ b/src/scheduler_server/app.py
@@ -125,7 +125,7 @@ def get_preset_config(preset_name, default={}):
             'fields': 'program,from,to,config,status'
         }
     }
-        
+
     presets = {
         'rest.satp1': {
             'url': os.environ['NOCODB_SATP1_URL'],

--- a/src/scheduler_server/handler.py
+++ b/src/scheduler_server/handler.py
@@ -55,7 +55,7 @@ def rest_handler(t0, t1, policy_config={}):
 
     if len(plans_overlap) == 0:
         raise ValueError("No active plan has any overlap with the requested period")
-    
+
     # sort to find plan with maximal overlap
     best_plan = sorted(plans_overlap, key=lambda x: (-x[0], x[1]))[0][-1]  # largest overlap and earliest in time.
     logger.info(f"Best plan found: {best_plan}")
@@ -88,7 +88,7 @@ def rest_handler(t0, t1, policy_config={}):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    schedule = module.main(t0, t1, **config)
+    schedule = module.main(t0=t0, t1=t1, **config)
 
     return schedule
 


### PR DESCRIPTION
This branch is for `scheduler-server` changes to accommodate automatic schedule generation.  Will merge once everything from start to end has been tested.

This is intended to work with a version of `scheduler-scripts` that calls a `get_state` function, so this should address #12 indirectly.  It is possible to incorporate the state checker into the server directly, but I decided to do it in `gen_schedule.py` as that takes the platform as input, sets up output directories, and handles file output.