### PR TITLE
Add ability to get cal_targets from linked cal_target table

### DIFF
--- a/src/scheduler_server/app.py
+++ b/src/scheduler_server/app.py
@@ -122,7 +122,7 @@ def get_preset_config(preset_name, default={}):
         },
         'queries': {
             'sort': '-from',
-            'fields': 'program,from,to,config,status'
+            'expand': 'cal_targets'
         }
     }
 

--- a/src/scheduler_server/handler.py
+++ b/src/scheduler_server/handler.py
@@ -68,6 +68,20 @@ def rest_handler(t0, t1, policy_config={}):
         config = yaml.safe_load(best_plan['config'])
         if isinstance(config, str):
             config = {"schedule": config}
+
+        # add cal targets from linked table
+        cal_keys = ['boresight', 'elevation', 'focus', 'allow_partial', 'az_speed', 'az_accel']
+        config['cal_targets'] = []
+        for i, source in enumerate(best_plan['cal_targets.source']):
+            if source is None:
+                raise ValueError("Source name is empty")
+            cal_target = {}
+            cal_target['source'] = source
+            for cal_key in cal_keys:
+                if best_plan['cal_targets.' + cal_key][i] is not None:
+                    cal_target[cal_key] = best_plan['cal_targets.' + cal_key][i]
+            config['cal_targets'].append(cal_target)
+        logger.info(f"best plan cal targets: {config['cal_targets']}")
     except Exception as e:
         logger.error(f"Failed to load yaml config with error: {e}")
         logger.error(f"config: {best_plan['config']}")


### PR DESCRIPTION
In order to support using a separate `nocodb` table with just calibration observations, this branch reads in linked rows from a separate table and builds a list of cal object dictionaries that are passed to `gen_schedule.py.`