### PR TITLE
Add default nocodb env url paths

### DIFF
--- a/src/scheduler_server/app.py
+++ b/src/scheduler_server/app.py
@@ -128,19 +128,19 @@ def get_preset_config(preset_name, default={}):
 
     presets = {
         'rest.satp1': {
-            'url': os.environ['NOCODB_SATP1_URL'],
+            'url': os.environ.get('NOCODB_SATP1_URL',""),
             **http_headers,
         },
         'rest.satp2': {
-            'url': os.environ['NOCODB_SATP2_URL'],
+            'url': os.environ.get('NOCODB_SATP2_URL',""),
             **http_headers,
         },
         'rest.satp3': {
-            'url': os.environ['NOCODB_SATP3_URL'],
+            'url': os.environ.get('NOCODB_SATP3_URL',""),
             **http_headers,
         },
         'rest.lat': {
-            'url': os.environ['NOCODB_LAT_URL'],
+            'url': os.environ.get('NOCODB_LAT_URL',""),
             **http_headers,
         }
     }


### PR DESCRIPTION
Makes the `Nocodb` url paths optional.  This removes the need for each `docker-compose` file to have all platform urls in it and prevents the wrong platform schedule from being run.