### PR TITLE
Make schedule end on nocodb end time, update timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN pip install .
 
 # Run server
 EXPOSE 8010
-ENTRYPOINT ["dumb-init", "gunicorn", "--bind", "0.0.0.0:8010", "--timeout", "120", "scheduler_server.app:app"]
+ENTRYPOINT ["dumb-init", "gunicorn", "--bind", "0.0.0.0:8010", "--timeout", "180", "scheduler_server.app:app"]

--- a/src/scheduler_server/handler.py
+++ b/src/scheduler_server/handler.py
@@ -88,7 +88,7 @@ def rest_handler(t0, t1, policy_config={}):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    schedule = module.main(t0=t0, t1=t1, **config)
+    schedule = module.main(t0=t0, t1=min(t1, datetime.fromisoformat(best_plan['to'])), **config)
 
     return schedule
 


### PR DESCRIPTION
This changes the end time sent to the scheduler to be the minimum of (`t0 + NEXTLINE_SCHEDULE__LENGTH_MINUTES`) or the end time of the selected best `nocodb` row (the column `to`).  This will prevent a schedule from continuing when it should instead be remade with new calibration targets.

Also bumps up the timeout time to 180 seconds as the state function seems to take longer in the docker container.