### PR TITLE
Expand to config table

### DIFF
--- a/src/scheduler_server/app.py
+++ b/src/scheduler_server/app.py
@@ -122,7 +122,7 @@ def get_preset_config(preset_name, default={}):
         },
         'queries': {
             'sort': '-from',
-            'expand': 'cal_targets'
+            'expand': 'cal_targets, config'
         }
     }
 


### PR DESCRIPTION
Since the config parameters rarely change for each platform and the calibration targets are added by linking a separate nocodb table, this branch adds a link to a config table that has only the config parameters in it.  This makes it so that the config parameters don't need to be added for every row.