### PR TITLE
Bump scheduler version, match add cal_targets keys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv
 requests
 socs
 sorunlib
-git+https://github.com/simonsobs/scheduler.git@d10137a5326cc48822212ae118fdb75bcf9d34ef
+git+https://github.com/simonsobs/scheduler.git@b603ec94acaa9893fdab7319ddec87e4b5552f51

--- a/src/scheduler_server/handler.py
+++ b/src/scheduler_server/handler.py
@@ -80,7 +80,8 @@ def rest_handler(t0, t1, policy_config={}):
             config = {"schedule": config}
 
         # add cal targets from linked table
-        cal_keys = ['boresight', 'elevation', 'focus', 'allow_partial', 'az_speed', 'az_accel', 'order']
+        cal_keys = ['boresight', 'elevation', 'focus', 'allow_partial', 'drift',
+                    'az_branch', 'az_speed', 'az_accel', 'source_direction', 'order']
         # don't overwrite any cal targets passed in the config
         if 'cal_targets' not in config:
             config['cal_targets'] = []


### PR DESCRIPTION
Increments the scheduler version, allowing for rising and setting calibration target scans to be specified.  Adds remaining `cal_target` keys to be read in from the `NocoDB` table.